### PR TITLE
chore: add new field custom_license_refs into license entity

### DIFF
--- a/entity/src/license.rs
+++ b/entity/src/license.rs
@@ -1,6 +1,6 @@
 use sea_orm::entity::prelude::*;
 
-#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, serde::Serialize)]
 #[sea_orm(table_name = "license")]
 pub struct Model {
     #[sea_orm(primary_key)]
@@ -8,6 +8,7 @@ pub struct Model {
     pub text: String,
     pub spdx_licenses: Option<Vec<String>>,
     pub spdx_license_exceptions: Option<Vec<String>>,
+    pub custom_license_refs: Option<Vec<String>>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/entity/src/license.rs
+++ b/entity/src/license.rs
@@ -9,6 +9,7 @@ pub struct Model {
     pub spdx_licenses: Option<Vec<String>>,
     pub spdx_license_exceptions: Option<Vec<String>>,
     pub custom_license_refs: Option<Vec<String>>,
+    pub custom_document_license_refs: Option<Vec<String>>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/etc/test-data/spdx/license-sbom.json
+++ b/etc/test-data/spdx/license-sbom.json
@@ -1,0 +1,393 @@
+{
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "comment": "Licensing information is automatically generated from the upstream package meta data and may not be accurate.",
+
+    "creationInfo": {
+        "created": "2024-09-04T11:34:57Z",
+        "creators": [
+            "Organization: Red Hat Product Security (secalert@redhat.com)"
+        ],
+        "licenseListVersion": "3.22"
+    },
+    "dataLicense": "CC0-1.0",
+    "hasExtractedLicensingInfos": [
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: GPLv2+. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-0",
+            "name": "GPLv2+"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: MIT/X License, GPL/CDDL, ASL2. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-1",
+            "name": "MIT/X License, GPL/CDDL, ASL2"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: ASL 2.0. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-2",
+            "name": "ASL 2.0"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: [{'license': {'id': None}}]. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-3",
+            "name": "[{'license': {'id': None}}]"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: GPL+. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-4",
+            "name": "GPL+"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: Artistic. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-Artistic",
+            "name": "Artistic"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: Artistic 2.0. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-5",
+            "name": "Artistic 2.0"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: UCD. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-UCD",
+            "name": "UCD"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: GPLv3+. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-6",
+            "name": "GPLv3+"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: BSD. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-BSD",
+            "name": "BSD"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: Copyright only. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-7",
+            "name": "Copyright only"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: LGPLv2+. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-8",
+            "name": "LGPLv2+"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: [{'license': {'id': 'Apache-2.0'}}]. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-9",
+            "name": "[{'license': {'id': 'Apache-2.0'}}]"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: LGPLv2. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-LGPLv2",
+            "name": "LGPLv2"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: MPLv1.1. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-MPLv1.1",
+            "name": "MPLv1.1"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: CC-BY. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-CC-BY",
+            "name": "CC-BY"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: GPLv3. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-GPLv3",
+            "name": "GPLv3"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: LGPLv3+. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-10",
+            "name": "LGPLv3+"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: GFDL. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-GFDL",
+            "name": "GFDL"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: HSRL. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-HSRL",
+            "name": "HSRL"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: GPLv3+ and GPLv3+ with exceptions and GPLv2+ and GPLv2+ with exceptions and GPL+ and LGPLv2+ and LGPLv3+ and BSD and Public Domain and GFDL. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-11",
+            "name": "GPLv3+ and GPLv3+ with exceptions and GPLv2+ and GPLv2+ with exceptions and GPL+ and LGPLv2+ and LGPLv3+ and BSD and Public Domain and GFDL"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: Public Domain. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-12",
+            "name": "Public Domain"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: GPL-2.0-with-classpath-exception. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-GPL-2.0-with-classpath-exception",
+            "name": "GPL-2.0-with-classpath-exception"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: MPL. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-MPL",
+            "name": "MPL"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: Netscape. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-Netscape",
+            "name": "Netscape"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: AFL. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-AFL",
+            "name": "AFL"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: GPLv2. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-GPLv2",
+            "name": "GPLv2"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: (FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-13",
+            "name": "(FTL or GPLv2+) and BSD and MIT and Public Domain and zlib with acknowledgement"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: JasPer. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-JasPer",
+            "name": "JasPer"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: EPL-2.0 OR GNU General Public License, version 2 with the GNU Classpath Exception. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-14",
+            "name": "EPL-2.0 OR GNU General Public License, version 2 with the GNU Classpath Exception"
+        },
+        {
+            "comment": "External License Info is obtained from a build system which predates the SPDX specification and is not strict in accepting valid SPDX licenses.",
+
+            "extractedText": "The license info found in the package meta data is: Boost. See the specific package info in this SPDX document or the package itself for more details.",
+
+            "licenseId": "LicenseRef-Boost",
+            "name": "Boost"
+        }
+    ],
+    "name": "license-sbom",
+    "spdxVersion": "SPDX-2.3",
+    "documentNamespace": "https://access.redhat.com/security/data/sbom/spdx/license-sbom",
+    "packages": [
+        {
+            "SPDXID": "SPDXRef-0861bbe4-5abe-43eb-85aa-cfaba755db35",
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "registry.redhat.io/openshift/ose-jenkins:v4.11.0-1706518192",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:oci/ose-jenkins@sha256:e45374e70943b41b54561d72f08af81ca10222d1427b83a7885f6143af8261ef?repository_url=registry.redhat.io/openshift/ose-jenkins&tag=v4.11.0-1706518192",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:redhat:ocp_tools:4.11::el8",
+                    "referenceType": "cpe22Type"
+                }
+            ],
+            "filesAnalyzed": false,
+            "homepage": "registry.redhat.io/openshift/ose-jenkins",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "LicenseRef-0",
+            "name": "openshift-jenkins-2-container",
+            "originator": "NOASSERTION",
+            "supplier": "Organization: Red Hat",
+            "versionInfo": "v4.11.0-1706518192"
+        },
+        {
+            "SPDXID": "SPDXRef-19c96199-1df1-4fba-a2e7-fed5421816dd",
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "https://access.redhat.com/downloads/content/package-browser",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:rpm/redhat/jenkins@2.426.3.1706516929-3.el8?arch=src",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:redhat:ocp_tools:4.11::el8",
+                    "referenceType": "cpe22Type"
+                }
+            ],
+            "filesAnalyzed": false,
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "(LicenseRef-1 AND MIT) OR DocumentRef-OCP-TOOLS-4.11-RHEL-8:LicenseRef-Netscape",
+            "name": "jenkins",
+            "originator": "NOASSERTION",
+            "packageFileName": "jenkins-2.426.3.1706516929-3.el8.src.rpm",
+            "supplier": "Organization: Red Hat",
+            "versionInfo": "2.426.3.1706516929-3.el8"
+        },
+        {
+            "SPDXID": "SPDXRef-5f910422-fa4c-4e97-b84c-59aebbc0d99e",
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "https://access.redhat.com/downloads/content/package-browser",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:rpm/redhat/helm@3.9.0-3.el8?arch=src",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:redhat:ocp_tools:4.11::el8",
+                    "referenceType": "cpe22Type"
+                }
+            ],
+            "filesAnalyzed": false,
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "LicenseRef-2",
+            "name": "helm",
+            "originator": "NOASSERTION",
+            "packageFileName": "helm-3.9.0-3.el8.src.rpm",
+            "supplier": "Organization: Red Hat",
+            "versionInfo": "3.9.0-3.el8"
+        },
+        {
+            "SPDXID": "SPDXRef-7ecb6789-1a95-4625-a48a-4fb1b0b5a45b",
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "https://access.redhat.com/downloads/content/package-browser",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:rpm/redhat/jenkins-2-plugins@4.11.1706516946-1.el8?arch=src",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:redhat:ocp_tools:4.11::el8",
+                    "referenceType": "cpe22Type"
+                }
+            ],
+            "filesAnalyzed": false,
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "LicenseRef-2",
+            "name": "jenkins-2-plugins",
+            "originator": "NOASSERTION",
+            "packageFileName": "jenkins-2-plugins-4.11.1706516946-1.el8.src.rpm",
+            "supplier": "Organization: Red Hat",
+            "versionInfo": "4.11.1706516946-1.el8"
+        },
+        {
+            "SPDXID": "SPDXRef-95107616-b673-4e1f-8144-f7e19e27ab31",
+            "copyrightText": "NOASSERTION",
+            "downloadLocation": "registry.redhat.io/openshift/jenkins-agent-base:v4.11.0-1706516858",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "pkg:oci/jenkins-agent-base@sha256:6b2401ee43270c3549378232a42411bd58874660216c9cd35ff0ed0ed0a94670?repository_url=registry.redhat.io/openshift/jenkins-agent-base&tag=v4.11.0-1706516858",
+                    "referenceType": "purl"
+                },
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceLocator": "cpe:/a:redhat:ocp_tools:4.11::el8",
+                    "referenceType": "cpe22Type"
+                }
+            ],
+            "filesAnalyzed": false,
+            "homepage": "registry.redhat.io/openshift/jenkins-agent-base",
+            "licenseConcluded": "(LicenseRef-JasPer AND LicenseRef-1) OR DocumentRef-OCP-TOOLS-4.11-RHEL-8:LicenseRef-MPL",
+            "licenseDeclared": "LicenseRef-0",
+            "name": "jenkins-agent-base-rhel8-container",
+            "originator": "NOASSERTION",
+            "supplier": "Organization: Red Hat",
+            "versionInfo": "v4.11.0-1706516858"
+        }
+    ]
+}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -25,6 +25,7 @@ mod m0001100_remove_get_purl;
 mod m0001110_sbom_node_checksum_indexes;
 mod m0001120_sbom_external_node_indexes;
 mod m0001130_gover_cmp;
+mod m0001150_license_add_custom_license_refs;
 
 pub struct Migrator;
 
@@ -57,6 +58,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0001110_sbom_node_checksum_indexes::Migration),
             Box::new(m0001120_sbom_external_node_indexes::Migration),
             Box::new(m0001130_gover_cmp::Migration),
+            Box::new(m0001150_license_add_custom_license_refs::Migration),
         ]
     }
 }

--- a/migration/src/m0001150_license_add_custom_license_refs.rs
+++ b/migration/src/m0001150_license_add_custom_license_refs.rs
@@ -1,0 +1,38 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(License::Table)
+                    .add_column(ColumnDef::new(License::CustomLicenseRefs).array(ColumnType::Text))
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(License::Table)
+                    .drop_column(License::CustomLicenseRefs)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum License {
+    Table,
+    CustomLicenseRefs,
+}

--- a/migration/src/m0001150_license_add_custom_license_refs.rs
+++ b/migration/src/m0001150_license_add_custom_license_refs.rs
@@ -11,6 +11,9 @@ impl MigrationTrait for Migration {
                 Table::alter()
                     .table(License::Table)
                     .add_column(ColumnDef::new(License::CustomLicenseRefs).array(ColumnType::Text))
+                    .add_column(
+                        ColumnDef::new(License::CustomDocumentLicenseRefs).array(ColumnType::Text),
+                    )
                     .to_owned(),
             )
             .await?;
@@ -24,6 +27,7 @@ impl MigrationTrait for Migration {
                 Table::alter()
                     .table(License::Table)
                     .drop_column(License::CustomLicenseRefs)
+                    .drop_column(License::CustomDocumentLicenseRefs)
                     .to_owned(),
             )
             .await?;
@@ -35,4 +39,5 @@ impl MigrationTrait for Migration {
 enum License {
     Table,
     CustomLicenseRefs,
+    CustomDocumentLicenseRefs,
 }

--- a/modules/fundamental/tests/sbom/license.rs
+++ b/modules/fundamental/tests/sbom/license.rs
@@ -1,5 +1,5 @@
 use flate2::read::GzDecoder;
-use sea_orm::{ColumnTrait, QuerySelect, EntityTrait, QueryFilter};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QuerySelect};
 
 use sea_query::Cond;
 use serde_json::{Value, json};
@@ -7,7 +7,9 @@ use std::io::Read;
 use tar::Archive;
 use test_context::test_context;
 use test_log::test;
-use trustify_entity::{sbom_package_license::LicenseCategory, license, sbom_package, sbom_package_license};
+use trustify_entity::{
+    license, sbom_package, sbom_package_license, sbom_package_license::LicenseCategory,
+};
 use trustify_module_fundamental::license::{
     model::sbom_license::SbomNameId,
     service::{LicenseService, license_export::LicenseExporter},

--- a/modules/ingestor/src/graph/sbom/common/license.rs
+++ b/modules/ingestor/src/graph/sbom/common/license.rs
@@ -11,6 +11,15 @@ const NAMESPACE: Uuid = Uuid::from_bytes([
     0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x41, 0x18, 0xa1, 0x38, 0xb8, 0x9f, 0x19, 0x35, 0xe0, 0xa7,
 ]);
 
+/// SPDX license information extracted from an SPDX expression
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SPDXInfo {
+    pub spdx_licenses: Vec<String>,
+    pub spdx_license_exceptions: Vec<String>,
+    pub custom_license_refs: Vec<String>,
+    pub custom_document_license_refs: Vec<String>,
+}
+
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct LicenseInfo {
     pub license: String,
@@ -22,7 +31,7 @@ impl LicenseInfo {
         Uuid::new_v5(&NAMESPACE, self.license.to_lowercase().as_bytes())
     }
 
-    pub fn spdx_info(&self) -> (Vec<String>, Vec<String>, Vec<String>, Vec<String>) {
+    pub fn spdx_info(&self) -> SPDXInfo {
         SpdxExpression::parse(&self.license)
             .map(|parsed| {
                 let spdx_licenses = parsed
@@ -53,23 +62,65 @@ impl LicenseInfo {
                     .licenses()
                     .iter()
                     .filter(|e| e.license_ref && e.document_ref.is_some())
-                    .map(|e| {
-                        if let Some(doc_ref) = &e.document_ref {
+                    .filter_map(|e| {
+                        e.document_ref.as_ref().map(|doc_ref| {
                             format!("DocumentRef-{}:LicenseRef-{}", doc_ref, e.identifier)
-                        } else {
-                            String::default()
-                        }
+                        })
                     })
                     .collect::<Vec<_>>();
 
-                (
+                SPDXInfo {
                     spdx_licenses,
                     spdx_license_exceptions,
                     custom_license_refs,
                     custom_document_license_refs,
-                )
+                }
             })
-            .unwrap_or((vec![], vec![], vec![], vec![]))
+            .unwrap_or(SPDXInfo {
+                spdx_licenses: vec![],
+                spdx_license_exceptions: vec![],
+                custom_license_refs: vec![],
+                custom_document_license_refs: vec![],
+            })
+    }
+}
+
+pub struct LicenseBuilder {
+    pub license_info: LicenseInfo,
+}
+
+impl LicenseBuilder {
+    pub fn new(license_info: LicenseInfo) -> Self {
+        Self { license_info }
+    }
+
+    pub fn to_active_model(&self) -> license::ActiveModel {
+        let spdx_info = self.license_info.spdx_info();
+
+        license::ActiveModel {
+            id: Set(self.license_info.uuid()),
+            text: Set(self.license_info.license.clone()),
+            spdx_licenses: if spdx_info.spdx_licenses.is_empty() {
+                Set(None)
+            } else {
+                Set(Some(spdx_info.spdx_licenses))
+            },
+            spdx_license_exceptions: if spdx_info.spdx_license_exceptions.is_empty() {
+                Set(None)
+            } else {
+                Set(Some(spdx_info.spdx_license_exceptions))
+            },
+            custom_license_refs: if spdx_info.custom_license_refs.is_empty() {
+                Set(None)
+            } else {
+                Set(Some(spdx_info.custom_license_refs))
+            },
+            custom_document_license_refs: if spdx_info.custom_document_license_refs.is_empty() {
+                Set(None)
+            } else {
+                Set(Some(spdx_info.custom_document_license_refs))
+            },
+        }
     }
 }
 
@@ -81,37 +132,42 @@ pub struct LicenseCreator {
     /// database.
     pub licenses: BTreeMap<Uuid, license::ActiveModel>,
 
-    pub custom_license_list: Vec<licensing_infos::ActiveModel>,
+    /// Custom license lookup map: license_id -> name
+    custom_license_map: std::collections::HashMap<String, String>,
 }
 
 impl LicenseCreator {
     pub fn new() -> Self {
         Self {
             licenses: Default::default(),
-            custom_license_list: vec![],
+            custom_license_map: std::collections::HashMap::new(),
         }
     }
 
     pub fn put_custom_license_list(
         &mut self,
-        custom_license_list: Vec<licensing_infos::ActiveModel>,
+        custom_license_list: &[licensing_infos::ActiveModel],
     ) {
-        self.custom_license_list = custom_license_list;
+        self.custom_license_map = custom_license_list
+            .iter()
+            .filter_map(|c| {
+                if let (Set(license_id), Set(name)) = (&c.license_id, &c.name) {
+                    Some((license_id.clone(), name.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
     }
 
     pub fn add(&mut self, info: &LicenseInfo) {
         let uuid = info.uuid();
 
-        let (spdx_licenses, spdx_exceptions, custom_license_refs, custom_document_license_refs) =
-            info.spdx_info();
-        let missing_custom_refs: Vec<_> = custom_license_refs
+        let spdx_info = info.spdx_info();
+        let missing_custom_refs: Vec<_> = spdx_info
+            .custom_license_refs
             .iter()
-            .filter(|ref_id| {
-                !self
-                    .custom_license_list
-                    .iter()
-                    .any(|c| c.license_id == Set((*ref_id).to_string()))
-            })
+            .filter(|ref_id| !self.custom_license_map.contains_key(*ref_id))
             .cloned()
             .collect();
         if !missing_custom_refs.is_empty() {
@@ -120,51 +176,30 @@ impl LicenseCreator {
                 missing_custom_refs
             );
         }
-        let custom_license_refs_value = if custom_license_refs.is_empty() {
+        let custom_license_refs_value = if spdx_info.custom_license_refs.is_empty() {
             None
         } else {
-            Some(self.construct_custom_license(custom_license_refs.clone()))
+            Some(self.construct_custom_license(spdx_info.custom_license_refs.clone()))
         };
 
-        self.licenses.entry(uuid).or_insert(license::ActiveModel {
-            id: Set(uuid),
-            text: Set(info.license.clone()),
-            spdx_licenses: if spdx_licenses.is_empty() {
-                Set(None)
-            } else {
-                Set(Some(spdx_licenses))
-            },
-            spdx_license_exceptions: if spdx_exceptions.is_empty() {
-                Set(None)
-            } else {
-                Set(Some(spdx_exceptions))
-            },
-            custom_license_refs: Set(custom_license_refs_value),
-            custom_document_license_refs: if custom_document_license_refs.is_empty() {
-                Set(None)
-            } else {
-                Set(Some(custom_document_license_refs))
-            },
-        });
+        let mut active_model = LicenseBuilder::new(info.clone()).to_active_model();
+
+        // Update custom_license_refs with constructed value
+        if let Some(refs) = custom_license_refs_value {
+            active_model.custom_license_refs = Set(Some(refs));
+        }
+
+        self.licenses.entry(uuid).or_insert(active_model);
     }
 
     fn construct_custom_license(&self, custom_license_ids: Vec<String>) -> Vec<String> {
-        use std::collections::HashMap;
-        // Build a HashMap from license_id to name for fast lookup
-        let license_map: HashMap<&String, &String> = self
-            .custom_license_list
-            .iter()
-            .filter_map(|c| {
-                if let (Set(license_id), Set(name)) = (&c.license_id, &c.name) {
-                    Some((license_id, name))
-                } else {
-                    None
-                }
-            })
-            .collect();
         custom_license_ids
             .into_iter()
-            .filter_map(|id| license_map.get(&id).map(|name| format!("{}:{}", id, name)))
+            .filter_map(|id| {
+                self.custom_license_map
+                    .get(&id)
+                    .map(|name| format!("{}:{}", id, name))
+            })
             .collect()
     }
 

--- a/modules/ingestor/src/graph/sbom/common/licensing_info.rs
+++ b/modules/ingestor/src/graph/sbom/common/licensing_info.rs
@@ -63,8 +63,8 @@ impl LicensingInfoCreator {
         });
     }
 
-    pub fn get_copy_license_refs(&self) -> Vec<licensing_infos::ActiveModel> {
-        self.license_refs.clone()
+    pub fn get_copy_license_refs(&self) -> &[licensing_infos::ActiveModel] {
+        &self.license_refs
     }
 
     #[instrument(skip_all, fields(num = self.license_refs.len()), err)]

--- a/modules/ingestor/src/graph/sbom/common/licensing_info.rs
+++ b/modules/ingestor/src/graph/sbom/common/licensing_info.rs
@@ -63,6 +63,10 @@ impl LicensingInfoCreator {
         });
     }
 
+    pub fn get_copy_license_refs(&self) -> Vec<licensing_infos::ActiveModel> {
+        self.license_refs.clone()
+    }
+
     #[instrument(skip_all, fields(num = self.license_refs.len()), err)]
     pub async fn create<C>(self, db: &C) -> Result<(), DbErr>
     where

--- a/modules/ingestor/src/graph/sbom/mod.rs
+++ b/modules/ingestor/src/graph/sbom/mod.rs
@@ -424,8 +424,7 @@ impl SbomContext {
             license: license.to_string(),
         };
 
-        let (spdx_licenses, spdx_exceptions, custom_license_refs, custom_document_license_refs) =
-            license_info.spdx_info();
+        let active_model = LicenseBuilder::new(license_info.clone()).to_active_model();
 
         let license = license::Entity::find_by_id(license_info.uuid())
             .one(connection)
@@ -434,33 +433,7 @@ impl SbomContext {
         let license = if let Some(license) = license {
             license
         } else {
-            license::ActiveModel {
-                id: Set(license_info.uuid()),
-                text: Set(license_info.license.clone()),
-                spdx_licenses: if spdx_licenses.is_empty() {
-                    Set(None)
-                } else {
-                    Set(Some(spdx_licenses))
-                },
-                spdx_license_exceptions: if spdx_exceptions.is_empty() {
-                    Set(None)
-                } else {
-                    Set(Some(spdx_exceptions))
-                },
-                custom_license_refs: if custom_license_refs.is_empty() {
-                    Set(None)
-                } else {
-                    Set(Some(custom_license_refs))
-                },
-
-                custom_document_license_refs: if custom_document_license_refs.is_empty() {
-                    Set(None)
-                } else {
-                    Set(Some(custom_document_license_refs))
-                },
-            }
-            .insert(connection)
-            .await?
+            active_model.insert(connection).await?
         };
 
         sbom_package_license::ActiveModel {

--- a/modules/ingestor/src/graph/sbom/mod.rs
+++ b/modules/ingestor/src/graph/sbom/mod.rs
@@ -424,7 +424,7 @@ impl SbomContext {
             license: license.to_string(),
         };
 
-        let (spdx_licenses, spdx_exceptions) = license_info.spdx_info();
+        let (spdx_licenses, spdx_exceptions, custom_license_refs) = license_info.spdx_info();
 
         let license = license::Entity::find_by_id(license_info.uuid())
             .one(connection)
@@ -445,6 +445,11 @@ impl SbomContext {
                     Set(None)
                 } else {
                     Set(Some(spdx_exceptions))
+                },
+                custom_license_refs: if custom_license_refs.is_empty() {
+                    Set(None)
+                } else {
+                    Set(Some(custom_license_refs))
                 },
             }
             .insert(connection)

--- a/modules/ingestor/src/graph/sbom/mod.rs
+++ b/modules/ingestor/src/graph/sbom/mod.rs
@@ -424,7 +424,8 @@ impl SbomContext {
             license: license.to_string(),
         };
 
-        let (spdx_licenses, spdx_exceptions, custom_license_refs) = license_info.spdx_info();
+        let (spdx_licenses, spdx_exceptions, custom_license_refs, custom_document_license_refs) =
+            license_info.spdx_info();
 
         let license = license::Entity::find_by_id(license_info.uuid())
             .one(connection)
@@ -450,6 +451,12 @@ impl SbomContext {
                     Set(None)
                 } else {
                     Set(Some(custom_license_refs))
+                },
+
+                custom_document_license_refs: if custom_document_license_refs.is_empty() {
+                    Set(None)
+                } else {
+                    Set(Some(custom_document_license_refs))
                 },
             }
             .insert(connection)

--- a/modules/ingestor/src/graph/sbom/spdx.rs
+++ b/modules/ingestor/src/graph/sbom/spdx.rs
@@ -198,6 +198,8 @@ impl SbomContext {
             license_extracted_refs.add(extracted_licensing_info);
         }
 
+        licenses.put_custom_license_list(license_extracted_refs.get_copy_license_refs());
+
         let mut packages =
             PackageCreator::with_capacity(self.sbom.sbom_id, sbom_data.package_information.len());
 


### PR DESCRIPTION
## Summary by Sourcery

Add support for extracting, resolving, and persisting custom SPDX license references in the SBOM ingestion flow and license entity.

New Features:
- Extend SPDXInfo to capture custom_license_refs and custom_document_license_refs from SPDX expressions.
- Add custom_license_refs and custom_document_license_refs columns to the license entity model and database schema.
- Introduce LicenseBuilder and enhance LicenseCreator to resolve and store custom license references using a lookup map.
- Integrate custom license list injection into the SBOM ingestion pipeline before license creation.

Enhancements:
- Add get_copy_license_refs method to LicensingInfoCreator for exposing custom license models.

Build:
- Add migration to alter the license table with custom_license_refs and custom_document_license_refs columns.

Tests:
- Add unit test to validate extraction and persistence of custom license and document references.