### PR TITLE
TC-2826	Packages List API - Add licenses array

### DIFF
--- a/entity/src/sbom_package_license.rs
+++ b/entity/src/sbom_package_license.rs
@@ -68,3 +68,21 @@ impl Related<super::license::Entity> for Entity {
 }
 
 impl ActiveModelBehavior for ActiveModel {}
+
+impl LicenseCategory {
+    /// Returns the string representation of the license category
+    ///
+    /// # Examples
+    /// ```
+    /// use trustify_entity::sbom_package_license::LicenseCategory;
+    ///
+    /// assert_eq!(LicenseCategory::Declared.show(), "Declared");
+    /// assert_eq!(LicenseCategory::Concluded.show(), "Concluded");
+    /// ```
+    pub fn show(&self) -> &'static str {
+        match self {
+            LicenseCategory::Declared => "Declared",
+            LicenseCategory::Concluded => "Concluded",
+        }
+    }
+}

--- a/entity/src/sbom_package_license.rs
+++ b/entity/src/sbom_package_license.rs
@@ -68,21 +68,3 @@ impl Related<super::license::Entity> for Entity {
 }
 
 impl ActiveModelBehavior for ActiveModel {}
-
-impl LicenseCategory {
-    /// Returns the string representation of the license category
-    ///
-    /// # Examples
-    /// ```
-    /// use trustify_entity::sbom_package_license::LicenseCategory;
-    ///
-    /// assert_eq!(LicenseCategory::Declared.show(), "Declared");
-    /// assert_eq!(LicenseCategory::Concluded.show(), "Concluded");
-    /// ```
-    pub fn show(&self) -> &'static str {
-        match self {
-            LicenseCategory::Declared => "Declared",
-            LicenseCategory::Concluded => "Concluded",
-        }
-    }
-}

--- a/modules/fundamental/src/common/mod.rs
+++ b/modules/fundamental/src/common/mod.rs
@@ -1,1 +1,11 @@
+use sea_orm::FromQueryResult;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
 pub mod service;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, FromQueryResult)]
+pub struct LicenseRefMapping {
+    pub license_id: String,
+    pub license_name: String,
+}

--- a/modules/fundamental/src/common/mod.rs
+++ b/modules/fundamental/src/common/mod.rs
@@ -1,5 +1,8 @@
+use crate::sbom::service::sbom::LicenseBasicInfo;
 use sea_orm::FromQueryResult;
+use sea_query::FromValueTuple;
 use serde::{Deserialize, Serialize};
+use trustify_entity::sbom_package_license::LicenseCategory;
 use utoipa::ToSchema;
 
 pub mod service;
@@ -8,4 +11,19 @@ pub mod service;
 pub struct LicenseRefMapping {
     pub license_id: String,
     pub license_name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct LicenseInfo {
+    pub license_name: String,
+    pub license_type: LicenseCategory,
+}
+
+impl From<LicenseBasicInfo> for LicenseInfo {
+    fn from(license_basic_info: LicenseBasicInfo) -> Self {
+        LicenseInfo {
+            license_name: license_basic_info.license_name,
+            license_type: LicenseCategory::from_value_tuple(license_basic_info.license_type),
+        }
+    }
 }

--- a/modules/fundamental/src/license/service/mod.rs
+++ b/modules/fundamental/src/license/service/mod.rs
@@ -1,6 +1,6 @@
-use crate::sbom::model::LicenseRefMapping;
 use crate::{
     Error,
+    common::LicenseRefMapping,
     license::model::{
         SpdxLicenseDetails, SpdxLicenseSummary,
         sbom_license::{

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -288,7 +288,7 @@ async fn test_purl_license_details(ctx: &TrustifyContext) -> Result<(), anyhow::
           "license_type": "concluded"
         }
       ],
-      "license_ref_mapping": [
+      "licenses_ref_mapping": [
         {
           "license_id": "LicenseRef-Netscape",
           "license_name": "Netscape"

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -281,11 +281,11 @@ async fn test_purl_license_details(ctx: &TrustifyContext) -> Result<(), anyhow::
       "licenses": [
         {
           "license_name": "(LicenseRef-8 OR LicenseRef-0 OR LicenseRef-MPL) AND (LicenseRef-Netscape OR LicenseRef-0 OR LicenseRef-8)",
-          "license_type": "Declared"
+          "license_type": "declared"
         },
         {
           "license_name": "NOASSERTION",
-          "license_type": "Concluded"
+          "license_type": "concluded"
         }
       ],
       "license_ref_mapping": [

--- a/modules/fundamental/src/purl/model/details/purl.rs
+++ b/modules/fundamental/src/purl/model/details/purl.rs
@@ -41,7 +41,7 @@ pub struct PurlDetails {
     pub base: BasePurlHead,
     pub advisories: Vec<PurlAdvisory>,
     pub licenses: Vec<LicenseInfo>,
-    pub license_ref_mapping: Vec<LicenseRefMapping>,
+    pub licenses_ref_mapping: Vec<LicenseRefMapping>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, FromQueryResult)]
@@ -149,7 +149,7 @@ impl PurlDetails {
             base: BasePurlHead::from_entity(&package),
             advisories: PurlAdvisory::from_entities(purl_statuses, product_statuses, tx).await?,
             licenses: purl_license_info,
-            license_ref_mapping,
+            licenses_ref_mapping: license_ref_mapping,
         })
     }
 }

--- a/modules/fundamental/src/sbom/endpoints/mod.rs
+++ b/modules/fundamental/src/sbom/endpoints/mod.rs
@@ -8,15 +8,15 @@ pub use query::*;
 
 use crate::{
     Error,
-    common::service::delete_doc,
+    common::{LicenseRefMapping, service::delete_doc},
     license::{
         get_sanitize_filename,
         service::{LicenseService, license_export::LicenseExporter},
     },
     sbom::{
         model::{
-            LicenseRefMapping, SbomExternalPackageReference, SbomNodeReference, SbomPackage,
-            SbomPackageRelation, SbomSummary, Which, details::SbomAdvisory,
+            SbomExternalPackageReference, SbomNodeReference, SbomPackage, SbomPackageRelation,
+            SbomSummary, Which, details::SbomAdvisory,
         },
         service::SbomService,
     },

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -2,19 +2,18 @@ pub mod details;
 pub mod raw_sql;
 
 use super::service::SbomService;
+use crate::common::LicenseInfo;
 use crate::{
     Error, common::LicenseRefMapping, purl::model::summary::purl::PurlSummary,
-    sbom::service::sbom::LicenseBasicInfo, source_document::model::SourceDocument,
+    source_document::model::SourceDocument,
 };
 use sea_orm::{ConnectionTrait, ModelTrait, PaginatorTrait, prelude::Uuid};
-use sea_query::FromValueTuple;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use tracing::instrument;
 use trustify_common::{cpe::Cpe, purl::Purl};
 use trustify_entity::{
-    labels::Labels, relationship::Relationship, sbom, sbom_node, sbom_package,
-    sbom_package_license::LicenseCategory, source_document,
+    labels::Labels, relationship::Relationship, sbom, sbom_node, sbom_package, source_document,
 };
 use utoipa::ToSchema;
 
@@ -133,21 +132,6 @@ pub struct SbomPackage {
     /// LicenseRef mappings
     #[cfg_attr(feature = "async-graphql", graphql(skip))]
     pub licenses_ref_mapping: Vec<LicenseRefMapping>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
-pub struct LicenseInfo {
-    pub license_name: String,
-    pub license_type: LicenseCategory,
-}
-
-impl From<LicenseBasicInfo> for LicenseInfo {
-    fn from(license_basic_info: LicenseBasicInfo) -> Self {
-        LicenseInfo {
-            license_name: license_basic_info.license_name,
-            license_type: LicenseCategory::from_value_tuple(license_basic_info.license_type),
-        }
-    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -3,10 +3,10 @@ pub mod raw_sql;
 
 use super::service::SbomService;
 use crate::{
-    Error, purl::model::summary::purl::PurlSummary, sbom::service::sbom::LicenseBasicInfo,
-    source_document::model::SourceDocument,
+    Error, common::LicenseRefMapping, purl::model::summary::purl::PurlSummary,
+    sbom::service::sbom::LicenseBasicInfo, source_document::model::SourceDocument,
 };
-use sea_orm::{ConnectionTrait, FromQueryResult, ModelTrait, PaginatorTrait, prelude::Uuid};
+use sea_orm::{ConnectionTrait, ModelTrait, PaginatorTrait, prelude::Uuid};
 use sea_query::FromValueTuple;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -148,12 +148,6 @@ impl From<LicenseBasicInfo> for LicenseInfo {
             license_type: LicenseCategory::from_value_tuple(license_basic_info.license_type),
         }
     }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, FromQueryResult)]
-pub struct LicenseRefMapping {
-    pub license_id: String,
-    pub license_name: String,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/modules/fundamental/src/sbom/service/sbom.rs
+++ b/modules/fundamental/src/sbom/service/sbom.rs
@@ -1,9 +1,10 @@
 use super::SbomService;
 use crate::{
     Error,
+    common::LicenseRefMapping,
     sbom::model::{
-        LicenseRefMapping, SbomExternalPackageReference, SbomNodeReference, SbomPackage,
-        SbomPackageRelation, SbomSummary, Which, details::SbomDetails,
+        SbomExternalPackageReference, SbomNodeReference, SbomPackage, SbomPackageRelation,
+        SbomSummary, Which, details::SbomDetails,
     },
 };
 use futures_util::{StreamExt, TryStreamExt, stream};
@@ -239,7 +240,7 @@ impl SbomService {
 
     /// Get all the tuples License ID, License Name from the licensing_infos table for a single SBOM
     #[instrument(skip(connection), err(level=tracing::Level::INFO))]
-    async fn get_licensing_infos<C: ConnectionTrait>(
+    pub async fn get_licensing_infos<C: ConnectionTrait>(
         connection: &C,
         sbom_id: Uuid,
     ) -> Result<BTreeMap<String, String>, Error> {
@@ -617,9 +618,9 @@ where
             JoinType::LeftJoin,
             sbom_package::Relation::PackageLicense.def(),
         ).join(
-            JoinType::LeftJoin,
-            sbom_package_license::Relation::License.def(),
-        )
+        JoinType::LeftJoin,
+        sbom_package_license::Relation::License.def(),
+    )
 }
 
 #[derive(FromQueryResult)]

--- a/modules/fundamental/tests/sbom/spdx/perf.rs
+++ b/modules/fundamental/tests/sbom/spdx/perf.rs
@@ -4,7 +4,7 @@ use test_log::test;
 use tracing::instrument;
 use trustify_common::model::Paginated;
 use trustify_entity::sbom_package_license::LicenseCategory;
-use trustify_module_fundamental::sbom::model::{LicenseInfo, SbomPackage};
+use trustify_module_fundamental::{common::LicenseInfo, sbom::model::SbomPackage};
 use trustify_test_context::TrustifyContext;
 
 #[test_context(TrustifyContext)]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4648,7 +4648,7 @@ components:
         - base
         - advisories
         - licenses
-        - license_ref_mapping
+        - licenses_ref_mapping
         properties:
           advisories:
             type: array
@@ -4656,14 +4656,14 @@ components:
               $ref: '#/components/schemas/PurlAdvisory'
           base:
             $ref: '#/components/schemas/BasePurlHead'
-          license_ref_mapping:
-            type: array
-            items:
-              $ref: '#/components/schemas/LicenseRefMapping'
           licenses:
             type: array
             items:
               $ref: '#/components/schemas/LicenseInfo'
+          licenses_ref_mapping:
+            type: array
+            items:
+              $ref: '#/components/schemas/LicenseRefMapping'
           version:
             $ref: '#/components/schemas/VersionedPurlHead'
     PurlHead:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4648,6 +4648,7 @@ components:
         - base
         - advisories
         - licenses
+        - license_ref_mapping
         properties:
           advisories:
             type: array
@@ -4655,10 +4656,14 @@ components:
               $ref: '#/components/schemas/PurlAdvisory'
           base:
             $ref: '#/components/schemas/BasePurlHead'
+          license_ref_mapping:
+            type: array
+            items:
+              $ref: '#/components/schemas/LicenseRefMapping'
           licenses:
             type: array
             items:
-              $ref: '#/components/schemas/PurlLicenseSummary'
+              $ref: '#/components/schemas/PurlLicenseInfo'
           version:
             $ref: '#/components/schemas/VersionedPurlHead'
     PurlHead:
@@ -4674,18 +4679,16 @@ components:
           type: string
           format: uuid
           description: The ID of the qualified PURL
-    PurlLicenseSummary:
+    PurlLicenseInfo:
       type: object
       required:
-      - sbom
-      - licenses
+      - license_name
+      - license_type
       properties:
-        licenses:
-          type: array
-          items:
-            type: string
-        sbom:
-          $ref: '#/components/schemas/SbomHead'
+        license_name:
+          type: string
+        license_type:
+          type: string
     PurlStatus:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4663,7 +4663,7 @@ components:
           licenses:
             type: array
             items:
-              $ref: '#/components/schemas/PurlLicenseInfo'
+              $ref: '#/components/schemas/LicenseInfo'
           version:
             $ref: '#/components/schemas/VersionedPurlHead'
     PurlHead:
@@ -4679,16 +4679,6 @@ components:
           type: string
           format: uuid
           description: The ID of the qualified PURL
-    PurlLicenseInfo:
-      type: object
-      required:
-      - license_name
-      - license_type
-      properties:
-        license_name:
-          type: string
-        license_type:
-          type: string
     PurlStatus:
       type: object
       required:


### PR DESCRIPTION
## Summary by Sourcery

Add license support to SBOM and Purl services, including license aggregation, SPDX reference mapping, and corresponding tests

New Features:
- Include a 'licenses' JSON array in SBOM package and Purl detail responses
- Expose a 'license_ref_mapping' array in API output by parsing SPDX LicenseRef expressions
- Make get_licensing_infos public for retrieving license ID-to-name mappings

Enhancements:
- Implement join_licenses and join_purls_and_cpes to aggregate license, PURL, and CPE data
- Introduce extract_license_ref_mappings utility to parse SPDX expressions
- Extend PurlDetails model with PurlLicenseInfo and PurlLicenseResult for license data
- Add LicenseCategory.show() method for license category string representation

Tests:
- Add integration test for verifying license details in the Purl endpoint